### PR TITLE
Add support for VGR reserve numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Validate Swedish personnummer (civic numbers), samordningsnummer (coordination numbers) and reservnummer (reserve numbers).
 
+### VGR reserve numbers
+For Västra Götalands region (VGR) there is a special format for reserve numbers used.
+
 ## Installation
 
 ```
@@ -24,6 +27,7 @@ composer require pinefox/personnummer
 | isFemale             | none            | bool    |
 | isCoordinationNumber | none            | bool    |
 | isReserveNumber      | none            | bool    |
+| isVgrReserveNumber   | none            | bool    |
 
 | Property | Type   | Description                 |
 | ---------|:-------|----------------------------:|
@@ -43,7 +47,8 @@ When a personnummer is invalid a PersonnummerException is thrown.
 | Option                  | Type | Default | Description                 |
 | ------------------------|:-----|:--------|:---------------------------:|
 | allowCoordinationNumber | bool | true    | Accept coordination numbers |
-| allowReserveNumber      | bool | true    | Accept reserve number       |
+| allowReserveNumber      | bool | true    | Accept reserve numbers      |
+| allowVgrReserveNumber   | bool | true    | Accept VGR reserve numbers  |
 
 ## Examples
 

--- a/src/Personnummer.php
+++ b/src/Personnummer.php
@@ -119,6 +119,11 @@ final class Personnummer implements PersonnummerInterface
         return checkdate((int)$parts['month'], $parts['day'] - 60, $parts['fullYear']);
     }
 
+    public function canUseBankId(): bool
+    {
+        return ! $this->isReserveNumber() && ! $this->isVgrReserveNumber();
+    }
+
     public static function valid(string $ssn, array $options = []): bool
     {
         try {

--- a/src/Personnummer.php
+++ b/src/Personnummer.php
@@ -119,11 +119,6 @@ final class Personnummer implements PersonnummerInterface
         return checkdate((int)$parts['month'], $parts['day'] - 60, $parts['fullYear']);
     }
 
-    public function canUseBankId(): bool
-    {
-        return ! $this->isReserveNumber() && ! $this->isVgrReserveNumber();
-    }
-
     public static function valid(string $ssn, array $options = []): bool
     {
         try {

--- a/src/Personnummer.php
+++ b/src/Personnummer.php
@@ -60,10 +60,14 @@ final class Personnummer implements PersonnummerInterface
      */
     public function isMale(): bool
     {
+        if ($this->reserveNumberCharacter === 'X' && $this->isVgrReserveNumber()) {
+            return false;
+        }
+
         $parts       = $this->parts;
         $genderDigit = substr($parts['num'], -1);
 
-        return boolval($genderDigit % 2);
+        return (bool)($genderDigit % 2);
     }
 
     /**
@@ -73,6 +77,10 @@ final class Personnummer implements PersonnummerInterface
      */
     public function isFemale(): bool
     {
+        if ($this->reserveNumberCharacter === 'X' && $this->isVgrReserveNumber()) {
+            return false;
+        }
+
         return !$this->isMale();
     }
 

--- a/src/Personnummer.php
+++ b/src/Personnummer.php
@@ -238,6 +238,7 @@ final class Personnummer implements PersonnummerInterface
     public function __construct(string $ssn, array $options = [])
     {
         $ssn = $this->checkIfReserveNumber($ssn);
+
         $this->options = $this->parseOptions($options);
         $this->parts   = self::getParts($ssn);
 
@@ -249,6 +250,12 @@ final class Personnummer implements PersonnummerInterface
     public function isReserveNumber(): bool
     {
         return $this->reserveNumberCharacter !== null;
+    }
+
+    public function isVgrReserveNumber(): bool
+    {
+        // TODO: implement
+        return false;
     }
 
     /**
@@ -306,6 +313,10 @@ final class Personnummer implements PersonnummerInterface
     {
         $parts = $this->parts;
 
+        if (! $this->options['allowVgrReserveNumber'] && $this->isVgrReserveNumber()) {
+            return false;
+        }
+
         if (! $this->options['allowReserveNumber'] && $this->isReserveNumber()) {
             return false;
         }
@@ -317,7 +328,7 @@ final class Personnummer implements PersonnummerInterface
         }
 
         $checkStr   = $parts['year'] . $parts['month'] . $parts['day'] . $parts['num'];
-        $validCheck = self::luhn($checkStr) === intval($parts['check']);
+        $validCheck = self::luhn($checkStr) === (int)$parts['check'];
 
         return $validDate && $validCheck;
     }
@@ -327,6 +338,7 @@ final class Personnummer implements PersonnummerInterface
         $defaultOptions = [
             'allowCoordinationNumber' => true,
             'allowReserveNumber' => true,
+            'allowVgrReserveNumber' => true,
         ];
 
         if ($unknownKeys = array_diff_key($options, $defaultOptions)) {

--- a/src/Personnummer.php
+++ b/src/Personnummer.php
@@ -27,6 +27,18 @@ final class Personnummer implements PersonnummerInterface
 
     private $reserveNumberCharacter;
 
+    private $isVgrReserve = false;
+
+    /**
+     * If VGR reserve number, replace 9th position character with mapped value and calculate check digit.
+     * @var int[]
+     */
+    private $vgrMapping = [
+        'K' => 5,
+        'M' => 7,
+        'X' => 8,
+    ];
+
     /**
      *
      * @param string $ssn
@@ -254,8 +266,7 @@ final class Personnummer implements PersonnummerInterface
 
     public function isVgrReserveNumber(): bool
     {
-        // TODO: implement
-        return false;
+        return ($this->reserveNumberCharacter !== null && $this->isVgrReserve);
     }
 
     /**

--- a/src/Personnummer.php
+++ b/src/Personnummer.php
@@ -324,10 +324,6 @@ final class Personnummer implements PersonnummerInterface
     {
         $parts = $this->parts;
 
-        if (! $this->options['allowVgrReserveNumber'] && $this->isVgrReserveNumber()) {
-            return false;
-        }
-
         if (! $this->options['allowReserveNumber'] && $this->isReserveNumber()) {
             return false;
         }

--- a/src/Personnummer.php
+++ b/src/Personnummer.php
@@ -104,7 +104,7 @@ final class Personnummer implements PersonnummerInterface
     {
         $parts = $this->parts;
 
-        return checkdate(intval($parts['month']), $parts['day'] - 60, $parts['fullYear']);
+        return checkdate((int)$parts['month'], $parts['day'] - 60, $parts['fullYear']);
     }
 
     public static function valid(string $ssn, array $options = []): bool
@@ -194,7 +194,7 @@ final class Personnummer implements PersonnummerInterface
         $sum = 0;
 
         for ($i = 0; $i < strlen($str); $i++) {
-            $v = intval($str[$i]);
+            $v = (int)$str[$i];
             $v *= 2 - ($i % 2);
 
             if ($v > 9) {
@@ -204,7 +204,7 @@ final class Personnummer implements PersonnummerInterface
             $sum += $v;
         }
 
-        return intval(ceil($sum / 10) * 10 - $sum);
+        return (int)ceil($sum / 10) * 10 - $sum;
     }
 
     /**
@@ -242,7 +242,7 @@ final class Personnummer implements PersonnummerInterface
         $this->options = $this->parseOptions($options);
         $this->parts   = self::getParts($ssn);
 
-        if (!$this->isValid()) {
+        if (! $this->isValid()) {
             throw new PersonnummerException();
         }
     }

--- a/tests/PersonnummerTest.php
+++ b/tests/PersonnummerTest.php
@@ -69,6 +69,75 @@ class PersonnummerTest extends TestCase
         $this->assertEquals('000101-T220', $differentLetterNumber->format());
     }
 
+    public function testVgrReserveNumbersForFemales()
+    {
+        $female = new Personnummer('19800906K148');
+        $this->assertEquals('800906-K148', $female->format());
+        $this->assertEquals('19800906K148', $female->format(true));
+        $this->assertTrue($female->isVgrReserveNumber());
+
+        // Wrong check digit:
+        $this->assertThrows(PersonnummerException::class, function () {
+            new Personnummer('19800906K149');
+        });
+
+        // Wrong gender letter (male):
+        $this->assertThrows(PersonnummerException::class, function () {
+            new Personnummer('19800906M148');
+        });
+
+        // Wrong gender letter (unknown):
+        $this->assertThrows(PersonnummerException::class, function () {
+            new Personnummer('19800906X148');
+        });
+    }
+
+    public function testVgrReserveNumbersForMales()
+    {
+        $male = new Personnummer('20121212M714');
+        $this->assertEquals('121212-M714', $male->format());
+        $this->assertEquals('20121212M714', $male->format(true));
+        $this->assertTrue($male->isVgrReserveNumber());
+
+        // Wrong check digit:
+        $this->assertThrows(PersonnummerException::class, function () {
+            new Personnummer('20121212M713');
+        });
+
+        // Wrong gender letter (female):
+        $this->assertThrows(PersonnummerException::class, function () {
+            new Personnummer('20121212K714');
+        });
+
+        // Wrong gender letter (unknown):
+        $this->assertThrows(PersonnummerException::class, function () {
+            new Personnummer('20121212X714');
+        });
+    }
+
+    public function testVgrReserveNumbersForUnknownGender()
+    {
+        $unknown = new Personnummer('20121212X803');
+        $this->assertEquals('121212-X803', $unknown->format());
+        $this->assertEquals('20121212X803', $unknown->format(true));
+        $this->assertTrue($unknown->isVgrReserveNumber());
+
+        // Wrong check digit:
+        $this->assertThrows(PersonnummerException::class, function () {
+            new Personnummer('20121212X804');
+        });
+
+        // Wrong gender letter (female):
+        $this->assertThrows(PersonnummerException::class, function () {
+            new Personnummer('20121212K803');
+        });
+
+        // Wrong gender letter (male):
+        $this->assertThrows(PersonnummerException::class, function () {
+            new Personnummer('20121212M803');
+        });
+    }
+
     public function testParseReserveNumber()
     {
         $this->assertEquals(new Personnummer('000101-R220'), Personnummer::parse('000101-R220'));

--- a/tests/PersonnummerTest.php
+++ b/tests/PersonnummerTest.php
@@ -49,6 +49,9 @@ class PersonnummerTest extends TestCase
         $this->assertThrows(PersonnummerException::class, function () {
             new Personnummer('000101-R220', ['allowReserveNumber' => false]);
         });
+        $this->assertThrows(PersonnummerException::class, function () {
+            new Personnummer('19800906K148', ['allowVgrReserveNumber' => false]);
+        });
         $this->assertError(function () {
             new Personnummer('1212121212', ['invalidOption' => true]);
         }, E_USER_WARNING);

--- a/tests/PersonnummerTest.php
+++ b/tests/PersonnummerTest.php
@@ -71,24 +71,28 @@ class PersonnummerTest extends TestCase
 
     public function testVgrReserveNumbersForFemales()
     {
-        $female = new Personnummer('19800906K148');
-        $this->assertEquals('800906-K148', $female->format());
-        $this->assertEquals('19800906K148', $female->format(true));
+        $female = new Personnummer('19561110-K064');
+        $this->assertEquals('561110-K064', $female->format());
+        $this->assertEquals('19561110K064', $female->format(true));
         $this->assertTrue($female->isVgrReserveNumber());
+
+        // Replacing K with '5' should produce the same check digit, but not identify as VGR:
+        $personnummer = new Personnummer('19561110-5064');
+        $this->assertFalse($personnummer->isVgrReserveNumber());
 
         // Wrong check digit:
         $this->assertThrows(PersonnummerException::class, function () {
-            new Personnummer('19800906K149');
+            new Personnummer('19561110-K065');
         });
 
         // Wrong gender letter (male):
         $this->assertThrows(PersonnummerException::class, function () {
-            new Personnummer('19800906M148');
+            new Personnummer('19561110-M064');
         });
 
         // Wrong gender letter (unknown):
         $this->assertThrows(PersonnummerException::class, function () {
-            new Personnummer('19800906X148');
+            new Personnummer('19561110-X064');
         });
     }
 


### PR DESCRIPTION
* Adds support for VGR reserve numbers.
* Note that "standard reserve numbers" are already added, which are much more simpler (replaces letters with value 1 to calculate check digit and hence validity).
* For validation, the utility checks input in multiple steps, returning true (so additional steps are then skipped):
  * Regular personnummer or samordningsnummer.
  * If not valid personnummer, check if its a standard reserve number.
  * If not valid standard reserve number, check if its a VGR reserve number.