### PR TITLE
RVB number must have reserve number character.

### DIFF
--- a/src/Personnummer.php
+++ b/src/Personnummer.php
@@ -543,7 +543,7 @@ final class Personnummer implements PersonnummerInterface
             $this->parts['century'] . $this->parts['year']
         );
 
-        $this->isRvbReserve = $validDate && $this->validateNumPartsForRvb();
+        $this->isRvbReserve = $validDate && $this->reserveNumberCharacter && $this->validateNumPartsForRvb();
 
         return $this->isRvbReserve;
     }


### PR DESCRIPTION
Sloppy check on RVB reserve numbers, must have character in 9th position to be valid.